### PR TITLE
Fix support for Laravel 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=7.0",
         "illuminate/database": "^5.3",
-        "nesbot/carbon": "^1.21",
+        "nesbot/carbon": ">=1.21",
         "illuminate/support": "^5.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=7.0",
         "illuminate/database": "^5.3",
-        "nesbot/carbon": ">=1.21",
+        "nesbot/carbon": ">=1.21 <3.0",
         "illuminate/support": "^5.3"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 5.8 uses Carbon v2. Because of this Composer will not require this package (it works fine on Carbon v2).